### PR TITLE
Add INCLUDE command to include other Pifiles easily in our script without using sh'isms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ default to *rpi.img* in the source file's directory.
 `INPLACE` does not create a copy of the image, but performs all further
 operations on the given image. This is an alternative to `FROM` and `TO`.
 
+#### `INCLUDE [PATH_TO_PIFILE]`
+`INCLUDE` includes the provided Pifile in the current one for modularity and 
+re-use. The included file _has_ to have a `.Pifile` extension which need not be 
+specified.
+
+
 #### `PUMP [SIZE]`
 `PUMP` increases the image's size about the given amount (suffixes K, M, G are allowed).
 

--- a/examples/Module-Hello.Pifile
+++ b/examples/Module-Hello.Pifile
@@ -1,0 +1,3 @@
+# This is a simple example for an `INCLUDE`able module.
+
+RUN echo "Included echo!"

--- a/examples/RPi-OpenWRT.Pifile
+++ b/examples/RPi-OpenWRT.Pifile
@@ -21,3 +21,7 @@ RUN hello
 # test if INSTALL works
 INSTALL "README.md" "/tmp/"
 RUN head -n1 "/tmp/README.md"
+
+# test an INCLUDE - both with and without the .Pifile extension
+INCLUDE examples/Module-Hello.Pifile
+INCLUDE examples/Module-Hello

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -37,7 +37,7 @@ INPLACE() {
 # Usage: INCLUDE path/to/pifile[.Pifile]
 INCLUDE() {
   filename="${$1%.*}"
-  SOURCE "${filename}.Pifile"
+  source "${filename}.Pifile"
 }
 
 # Stage 2x

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -31,6 +31,10 @@ INPLACE() {
   :
 }
 
+INCLUDE() {
+  :
+}
+
 # Stage 2x
 PUMP() {
   :

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -23,6 +23,7 @@ post_stage() {
 # Usage: INCLUDE path/to/pifile[.Pifile]
 INCLUDE() {
   filename="${1%.*}"
+  # shellcheck disable=SC1090
   source "${filename}.Pifile"
 }
 

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -18,6 +18,14 @@ post_stage() {
   :
 }
 
+# INCLUDE sources the provided Pifile
+#
+# Usage: INCLUDE path/to/pifile[.Pifile]
+INCLUDE() {
+  filename="${1%.*}"
+  source "${filename}.Pifile"
+}
+
 # Stage 1x
 FROM() {
   :
@@ -31,14 +39,6 @@ INPLACE() {
   :
 }
 
-
-# INCLUDE sources the provided Pifile
-#
-# Usage: INCLUDE path/to/pifile[.Pifile]
-INCLUDE() {
-  filename="${$1%.*}"
-  source "${filename}.Pifile"
-}
 
 # Stage 2x
 PUMP() {

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -31,8 +31,13 @@ INPLACE() {
   :
 }
 
+
+# INCLUDE sources the provided Pifile
+#
+# Usage: INCLUDE path/to/pifile[.Pifile]
 INCLUDE() {
-  :
+  filename="${$1%.*}"
+  SOURCE "${filename}.Pifile"
 }
 
 # Stage 2x

--- a/stages/10-setup.sh
+++ b/stages/10-setup.sh
@@ -93,3 +93,10 @@ INPLACE() {
   FROM "$@"
   TO "$1"
 }
+
+# INCLUDE sources the provided Pifile
+#
+# Usage: INCLUDE path/to/pifile
+INCLUDE() {
+  SOURCE "${1}.Pifile"
+}

--- a/stages/10-setup.sh
+++ b/stages/10-setup.sh
@@ -93,10 +93,3 @@ INPLACE() {
   FROM "$@"
   TO "$1"
 }
-
-# INCLUDE sources the provided Pifile
-#
-# Usage: INCLUDE path/to/pifile
-INCLUDE() {
-  source "${1}.Pifile"
-}

--- a/stages/10-setup.sh
+++ b/stages/10-setup.sh
@@ -98,5 +98,5 @@ INPLACE() {
 #
 # Usage: INCLUDE path/to/pifile
 INCLUDE() {
-  SOURCE "${1}.Pifile"
+  source "${1}.Pifile"
 }


### PR DESCRIPTION
To include other Pifiles, it's easy to use the `source` command, but this detracts from the Dockerfile-like nature of pimod. The `INCLUDE` command lets us do this, while ensuring that only Pifiles can be included (it appends a `.Pifile` to the provided filename).