### PR TITLE
Add dockerhub example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ docker run --rm --privileged -v $PWD:/pimod pimod pimod.sh examples/RPi-OpenWRT.
 
 # …alternatively use docker-compose
 docker-compose run pimod pimod.sh examples/RPi-OpenWRT.Pifile
+
+# …alternatively use the latest image directly from dockerhub
+# the following commandline maps the current dir to /files
+docker run --rm --privileged \
+    -v $PWD:/files \
+    -e PATH=/pimod:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    --workdir=/files \
+    nature40/pimod \
+    pimod.sh /files/RPi-OpenWRT.pifile
 ```
 
 ### GitHub Actions


### PR DESCRIPTION
Small addition of an example using dockerhub. The `-e PATH=` is a bit unfortunate. I believe it's required right now. Maybe some setting of PATH in the `pimod.sh` script could alleviate that...