### PR TITLE
Add Extract command that allows to copy files from the image to the localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - New `ENV` command for environment variables.
+- New `EXTRACT` command to copy files back to the host; @sensslen.
 
 ## [0.4.4] - 2021-11-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ The included file _has_ to have a `.Pifile` extension which need not be specifie
 `INSTALL` installs a given file or directory into the destination in the image.
 The optionally permission mode (*chmod*) can be set as the first parameter.
 
+#### `EXTRACT SOURCE DEST`
+`EXTRACT` copies a given file or directory from the image to the destination.
+
 #### `PATH /my/guest/path`
 `PATH` adds the given path to an overlaying PATH variable, used within the `RUN` command.
 

--- a/examples/RPi-OpenWRT.Pifile
+++ b/examples/RPi-OpenWRT.Pifile
@@ -23,6 +23,10 @@ INSTALL "README.md" "/tmp/"
 WORKDIR /tmp
 RUN head -n1 "README.md"
 
+# test if EXTRACT works
+RUN sh -c 'echo "hello from within the guest" > /tmp/hello'
+EXTRACT "/tmp/hello" "./hello"
+
 # test an INCLUDE - both with and without the .Pifile extension
 INCLUDE examples/Module-Hello.Pifile
 INCLUDE examples/Module-Hello

--- a/stages/00-commands.sh
+++ b/stages/00-commands.sh
@@ -49,6 +49,10 @@ INSTALL() {
   :
 }
 
+EXTRACT() {
+  :
+}
+
 PATH() {
   :
 }

--- a/stages/30-chroot.sh
+++ b/stages/30-chroot.sh
@@ -47,7 +47,7 @@ INSTALL() {
 #
 # Usage: EXTRACT SOURCE DEST
 EXTRACT() {
-  echo -e "\033[0;32m### INSTALL $*\033[0m"
+  echo -e "\033[0;32m### EXTRACT $*\033[0m"
   
   local src="${CHROOT_MOUNT}/$1"
   local dst=$2

--- a/stages/30-chroot.sh
+++ b/stages/30-chroot.sh
@@ -43,6 +43,22 @@ INSTALL() {
   fi
 }
 
+# EXTRACT copies a given file or directory from the image to the destination. 
+#
+# Usage: EXTRACT SOURCE DEST
+EXTRACT() {
+  echo -e "\033[0;32m### INSTALL $*\033[0m"
+  
+  local src="${CHROOT_MOUNT}/$1"
+  local dst=$2
+
+  if [[ -d "${src}" ]]; then
+    cp -r -T -P --preserve=mode "${src}" "${dst}"
+  else
+    cp -r -P --preserve=mode "${src}" "${dst}"
+  fi
+}
+
 # PATH adds the given path to an overlaying PATH variable, used within the RUN
 # command.
 #


### PR DESCRIPTION
With this PR we get the ability to easily copy Copy files from the image back to the host. This allows to generate compainon files on the target and have them available on the host for further processing.

In my case, I want to generate an info file similar to the one provided by the raspberry pi foundation that states what software packages are installed on the system.