### PR TITLE
make sure the host version of reslov.conf is used in any case

### DIFF
--- a/modules/env.sh
+++ b/modules/env.sh
@@ -1,5 +1,6 @@
 # ENV_VARS is an associative array of environment variables, set via ENV.
 declare -A ENV_VARS=()
+ENV_VARS["PIMOD"]="true"
 
 # env_vars_set saves an environment variable mapping.
 # Usage: env_vars_set KEY VALUE

--- a/modules/resolv_conf.sh
+++ b/modules/resolv_conf.sh
@@ -3,11 +3,7 @@
 resolv_conf_setup() {
   local resolv_conf="${CHROOT_MOUNT}/etc/resolv.conf"
 
-  if [[ -f "${resolv_conf}" ]] && [[ -s "${resolv_conf}" ]]; then
-    return
-  fi
-
-  if [[ -L "${resolv_conf}" ]]; then
+  if [[ -f "${resolv_conf}" ]] || [[ -L "${resolv_conf}" ]]; then
     RESOLV_CONF_BACKUP=$(mktemp -u)
     mv "${resolv_conf}" "${RESOLV_CONF_BACKUP}"
   fi

--- a/modules/resolv_conf.sh
+++ b/modules/resolv_conf.sh
@@ -4,7 +4,7 @@ resolv_conf_setup() {
   local resolv_conf="${CHROOT_MOUNT}/etc/resolv.conf"
 
   if [[ -f "${resolv_conf}" ]] || [[ -L "${resolv_conf}" ]]; then
-    RESOLV_CONF_BACKUP=$(mktemp -u)
+    RESOLV_CONF_BACKUP="${CHROOT_MOUNT}/etc/resolv.conf.backup"
     mv "${resolv_conf}" "${RESOLV_CONF_BACKUP}"
   fi
 


### PR DESCRIPTION
With this PR we make sure that the host's resolv.conf is used in any case during chroot. I don't see why the mechanism used to do this differently. In any case: this fixes #54.