### PR TITLE
from_remote: support tarball images for remote FROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    The title should be `${VERSION} - ${YYYY-MM-DD}` and the description should contain the section from this `CHANGELOG.md`.
 
 ## [Unreleased]
+### Added
+- `FROM` with a remote URL now supports compressed tarballs (`.tar.gz`, `.tar.xz`) and plain tarballs (`.tar`) in addition to bare compressed images.
+  - Gzip/xz payloads are inspected after decompression: if the result is a tarball it is extracted, otherwise it is used directly as the image (preserving the previous behaviour for `.img.gz`/`.img.xz`).
 
 ## [0.9.1] - 2024-12-22
 ### Fixed

--- a/modules/from_remote.sh
+++ b/modules/from_remote.sh
@@ -62,16 +62,47 @@ from_remote_fetch() {
       unarchive_image "${download_path}" "${tmpfile}"
       ;;
 
-    application/gzip)
-      gunzip -c "${download_path}" > "${tmpfile}"
-      ;;
+    application/gzip | application/x-gzip)
+      # Decompress and check if it's a tarball
+      local decompressed
+      decompressed=$(mktemp)
+      gunzip -c "${download_path}" > "${decompressed}"
 
-    application/x-gzip)
-      gunzip -c "${download_path}" > "${tmpfile}"
+      local decompressed_mime
+      decompressed_mime=$(file -b --mime-type "${decompressed}")
+
+      if [[ "${decompressed_mime}" == "application/x-tar" ]]; then
+        # It's a .tar.gz, extract the tarball
+        unarchive_image "${decompressed}" "${tmpfile}"
+        rm "${decompressed}"
+      else
+        # Just a gzipped image
+        mv "${decompressed}" "${tmpfile}"
+      fi
       ;;
 
     application/x-xz)
-      unxz -c "${download_path}" > "${tmpfile}"
+      # Decompress and check if it's a tarball
+      local decompressed
+      decompressed=$(mktemp)
+      unxz -c "${download_path}" > "${decompressed}"
+
+      local decompressed_mime
+      decompressed_mime=$(file -b --mime-type "${decompressed}")
+
+      if [[ "${decompressed_mime}" == "application/x-tar" ]]; then
+        # It's a .tar.xz, extract the tarball
+        unarchive_image "${decompressed}" "${tmpfile}"
+        rm "${decompressed}"
+      else
+        # Just an xz compressed image
+        mv "${decompressed}" "${tmpfile}"
+      fi
+      ;;
+
+    application/x-tar)
+      # Plain tarball
+      unarchive_image "${download_path}" "${tmpfile}"
       ;;
 
     *)


### PR DESCRIPTION
Remote FROM only handled bare compressed images (.img.gz / .img.xz) and zip/7z archives. Compressed or plain tarballs that wrap a disk image (.tar.gz, .tar.xz, .tar) were rejected with an unknown MIME error.

This decompresses gzip/xz payloads to a temp file and checks the result: if it is a tarball, it is extracted with the existing unarchive_image helper (largest member is used as the image); otherwise it is used directly as before. A plain application/x-tar case is added for uncompressed tarballs. Existing .img.gz / .img.xz behavior is unchanged.

Testing: verified locally that .img.gz and .img.xz are passed through untouched, and that .tar.gz / .tar.xz / .tar sources route to the extractor. shellcheck -s bash -x pimod.sh passes.

No example is added to the CI matrix because there is no public tarball disk-image URL to point at (Pi/OpenWRT/Jetson images all ship as .zip or .img.xz). Happy to host a fixture and wire up a matrix test if you want one.