### PR TITLE
pimod: resolve module and stage paths via BASH_SOURCE

### DIFF
--- a/modules/pifile.sh
+++ b/modules/pifile.sh
@@ -31,17 +31,25 @@ execute_pifile() {
 
   bash -n "$1"
 
+  # Resolve absolute paths for modules and stages so pimod works when
+  # invoked via a symlink or from a different working directory.
+  MODULE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+  STAGES_DIR="${MODULE_DIR}/../stages"
+
+  # Absolute path to the provided Pifile.
+  PIFILE_ABS="$(cd -P "$(dirname "$1")" >/dev/null && pwd)/$(basename "$1")"
+
   declare -a stages=( "10-setup" "20-prepare" "30-chroot" "40-postprocess" "50-finalize" )
   for stage in "${stages[@]}"; do
-    pushd "$(dirname "$0")/modules" > /dev/null || exit 2
-    . "../stages/00-commands.sh"
-    . "../stages/${stage}.sh"
-    popd > /dev/null || exit 2
+    # shellcheck disable=SC1090
+    . "${STAGES_DIR}/00-commands.sh"
+    # shellcheck disable=SC1090
+    . "${STAGES_DIR}/${stage}.sh"
 
     pre_stage
 
     # shellcheck disable=SC1090
-    . "$1"
+    . "${PIFILE_ABS}"
 
     post_stage
   done

--- a/pimod.sh
+++ b/pimod.sh
@@ -2,21 +2,26 @@
 
 set -euE
 
-pushd "$(dirname "$0")" > /dev/null
+# Resolve the script directory even when the script is symlinked
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SCRIPT_SOURCE")" >/dev/null && pwd)"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ "$SCRIPT_SOURCE" != /* ]] && SCRIPT_SOURCE="$DIR/$SCRIPT_SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_SOURCE")" >/dev/null && pwd)"
 
-. ./modules/chroot.sh
-. ./modules/env.sh
-. ./modules/error.sh
-. ./modules/esceval.sh
-. ./modules/from_remote.sh
-. ./modules/mount.sh
-. ./modules/path.sh
-. ./modules/pifile.sh
-. ./modules/qemu.sh
-. ./modules/resolv_conf.sh
-. ./modules/workdir.sh
-
-popd > /dev/null
+. "$SCRIPT_DIR/modules/chroot.sh"
+. "$SCRIPT_DIR/modules/env.sh"
+. "$SCRIPT_DIR/modules/error.sh"
+. "$SCRIPT_DIR/modules/esceval.sh"
+. "$SCRIPT_DIR/modules/from_remote.sh"
+. "$SCRIPT_DIR/modules/mount.sh"
+. "$SCRIPT_DIR/modules/path.sh"
+. "$SCRIPT_DIR/modules/pifile.sh"
+. "$SCRIPT_DIR/modules/qemu.sh"
+. "$SCRIPT_DIR/modules/resolv_conf.sh"
+. "$SCRIPT_DIR/modules/workdir.sh"
 
 show_help() {
   cat <<EOF


### PR DESCRIPTION
pimod.sh and execute_pifile find modules and stages using $(dirname "$0") and pushd into relative paths (./modules, ../stages). This breaks when pimod.sh is run through a symlink or from a working directory other than the repo root, because $0 and the relative paths no longer point at the install location.

This resolves the real script directory from BASH_SOURCE, following symlinks, and sources modules, stages, and the Pifile via absolute paths. A direct in-repo invocation behaves exactly as before.

Testing: ran pimod via a symlink from a different working directory. On master it fails to source ./modules/*; with this change the modules, all five stages, and the Pifile resolve correctly. shellcheck -s bash -x pimod.sh passes.